### PR TITLE
Attempt to build at Darwin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ cabal.project.local~
 .HTF/
 .ghc.environment.*
 .nix/
+.vscode

--- a/default.nix
+++ b/default.nix
@@ -30,7 +30,7 @@ let deps = {
       # haskell.nix provides access to the nixpkgs pins which are used by our CI,
       # hence you will be more likely to get cache hits when using these.
       # But you can also just use your own, e.g. '<nixpkgs>'.
-      haskellNix.sources.nixpkgs-unstable
+      haskellNix.sources.nixpkgs-2405
       # These arguments passed to nixpkgs, include some patches and also
       # the haskell.nix functionality itself as an overlay.
       haskellNix.nixpkgsArgs;
@@ -63,9 +63,12 @@ let deps = {
           lines = pkgs.lib.strings.splitString "\n" content;
       in pkgs.lib.strings.concatStringsSep "\n" (
           pkgs.lib.lists.forEach lines (line:
-            if pkgs.lib.strings.hasPrefix "import: " line
-            then import-cabal-project dir (pkgs.lib.strings.removePrefix "import: " line)
-            else line
+            if pkgs.lib.strings.hasPrefix "if !arch(javascript)" line
+              then "if false"
+              else
+                if pkgs.lib.strings.hasPrefix "import: " line
+                then import-cabal-project dir (pkgs.lib.strings.removePrefix "import: " line)
+                else line
           )
       );
 


### PR DESCRIPTION
Does not build

```
ghc> Build failed.
error: builder for '/nix/store/sqpb67m3d7cghmi7piiz3gw37m7hlkn4-ghc-9.10.1.drv' failed with exit code 1;
       last 25 log lines:
       > Command line: _build/stage0/bin/ghc -Wall -Wcompat -dynamic-too -hisuf hi -osuf o -hcsuf hc -static -hide-all-packages -no-user-package-db '-package-env -' '-package-db _build/stage1/inplace/package.conf.d' '-this-unit-id unix-2.8.5.1-inplace' '-this-package-name unix' '-package-id base-4.20.0.0-inplace' '-package-id bytestring-0.12.1.0-inplace' '-package-id filepath-1.5.2.0-inplace' '-package-id os-string-2.0.2-inplace' '-package-id time-1.12.2-inplace' -i -i/private/tmp/nix-build-ghc-9.10.1.drv-0/ghc-6d779c0/_build/stage1/libraries/unix/build -i/private/tmp/nix-build-ghc-9.10.1.drv-0/ghc-6d779c0/_build/stage1/libraries/unix/build/autogen -i/private/tmp/nix-build-ghc-9.10.1.drv-0/ghc-6d779c0/libraries/unix -Irts/include -I_build/stage1/libraries/unix/build -I_build/stage1/libraries/unix/build/include -Ilibraries/unix/include -I/private/tmp/nix-build-ghc-9.10.1.drv-0/ghc-6d779c0/libraries/time/lib/include -I/private/tmp/nix-build-ghc-9.10.1.drv-0/ghc-6d779c0/_build/stage1/libraries/time/build/lib/include -I/private/tmp/nix-build-ghc-9.10.1.drv-0/ghc-6d779c0/libraries/bytestring/include -I/private/tmp/nix-build-ghc-9.10.1.drv-0/ghc-6d779c0/_build/stage1/libraries/bytestring/build/include -I/nix/store/m64893vyaf5amdx9jwqwh5jbr79r4kvf-libiconv-99/include -I/private/tmp/nix-build-ghc-9.10.1.drv-0/ghc-6d779c0/libraries/ghc-internal/include -I/private/tmp/nix-build-ghc-9.10.1.drv-0/ghc-6d779c0/_build/stage1/libraries/ghc-internal/build/include -I/nix/store/vibj1n4bjr6zribaj55jrigyh7dknnpm-gmp-with-cxx-6.3.0-dev/include -I/private/tmp/nix-build-ghc-9.10.1.drv-0/ghc-6d779c0/libraries/ghc-bignum/include/ -I/private/tmp/nix-build-ghc-9.10.1.drv-0/ghc-6d779c0/_build/stage1/libraries/ghc-bignum/build/include/ -I/nix/store/8a2mcjvzy0a6c5f700j3bhzaqshzp198-libffi-3.4.6-dev/include -I/private/tmp/nix-build-ghc-9.10.1.drv-0/ghc-6d779c0/rts/include -I/private/tmp/nix-build-ghc-9.10.1.drv-0/ghc-6d779c0/_build/stage1/rts/build/include -optP-include -optP_build/stage1/libraries/unix/build/autogen/cabal_macros.h -optc--target=x86_64-apple-darwin -optc-Qunused-arguments -outputdir _build/stage1/libraries/unix/build -fdiagnostics-color=always -Wall -XHaskell2010 -no-global-package-db -package-db=/private/tmp/nix-build-ghc-9.10.1.drv-0/ghc-6d779c0/_build/stage1/inplace/package.conf.d -ghcversion-file=rts/include/ghcversion.h -ghcversion-file=rts/include/ghcversion.h -Wnoncanonical-monad-instances -optc-Wno-unknown-pragmas -optP-Wno-nonportable-include-path -c _build/stage1/libraries/unix/build/System/Posix/Env/ByteString.hs -o _build/stage1/libraries/unix/build/System/Posix/Env/ByteString.o -O2 -H32m -haddock -Wno-deprecated-flags -Wno-deprecations
       > ===> Command failed with error code: -11
       > Error when running Shake build system:
       >   at action, called at src/Rules.hs:39:19 in main:Rules
       >   at need, called at src/Rules.hs:61:5 in main:Rules
       > * Depends on: _build/stage1/lib/package.conf.d/unix-2.8.5.1-inplace.conf
       >   at need, called at src/Rules/Register.hs:140:5 in main:Rules.Register
       > * Depends on: _build/stage1/libraries/unix/build/stamp-unix-2.8.5.1-inplace
       >   at need, called at src/Rules/Library.hs:144:3 in main:Rules.Library
       > * Depends on: _build/stage1/libraries/unix/build/libHSunix-2.8.5.1-inplace.a
       >   at need, called at src/Rules/Library.hs:220:5 in main:Rules.Library
       > * Depends on: _build/stage1/libraries/unix/build/System/Posix/Env/ByteString.o
       >   at &%>, called at src/Rules/Compile.hs:87:18 in main:Rules.Compile
       >   at &%>, called at src/Base.hs:189:22 in main:Base
       > * Depends on: _build/stage1/libraries/unix/build/System/Posix/Env/ByteString.o _build/stage1/libraries/unix/build/System/Posix/Env/ByteString.hi
       >   at cmd', called at src/Builder.hs:382:23 in main:Builder
       >   at cmdArgs, called at src/Builder.hs:552:8 in main:Builder
       >   at cmdArgs, called at src/Builder.hs:576:18 in main:Builder
       >   at cmdArgs, called at src/Builder.hs:576:18 in main:Builder
       >   at cmdArgs, called at src/Builder.hs:576:18 in main:Builder
       >   at error, called at src/Builder.hs:621:13 in main:Builder
       > * Raised the exception:
       > Command failed
       >
       > Build failed.
```

Full log is attached
[log.log](https://github.com/user-attachments/files/16679114/log.log)
